### PR TITLE
Black Pixel V4: Apply more accent color overrides, improve tabs, sidebar

### DIFF
--- a/CustomSkinsPackage/Black Pixel.xaml
+++ b/CustomSkinsPackage/Black Pixel.xaml
@@ -8,21 +8,21 @@
             <ResourceDictionary.MergedDictionaries>
                 <Windows10version1809:ColorPaletteResources
                     Accent="#1A73E8"
-                    AltHigh="#000000"
-                    AltLow="#000000"
-                    AltMedium="#000000"
-                    AltMediumHigh="#000000"
-                    AltMediumLow="#000000"
-                    BaseHigh="#FFFFFF"
+                    AltHigh="#000"
+                    AltLow="#000"
+                    AltMedium="#99000000"
+                    AltMediumHigh="#000"
+                    AltMediumLow="#000"
+                    BaseHigh="#FFF"
                     BaseLow="#212121"
-                    BaseMedium="#FFFFFF"
-                    BaseMediumHigh="#FFFFFF"
-                    BaseMediumLow="#99FFFFFF"
+                    BaseMedium="#FFF"
+                    BaseMediumHigh="#FFF"
+                    BaseMediumLow="#AAA"
                     ChromeAltLow="#212121"
-                    ChromeBlackHigh="#000000"
-                    ChromeBlackLow="#000000"
-                    ChromeBlackMedium="#000000"
-                    ChromeBlackMediumLow="#000000"
+                    ChromeBlackHigh="#000"
+                    ChromeBlackLow="#000"
+                    ChromeBlackMedium="#000"
+                    ChromeBlackMediumLow="#000"
                     ChromeDisabledHigh="#212121"
                     ChromeDisabledLow="#1A73E8"
                     ChromeGray="#212121"
@@ -30,29 +30,55 @@
                     ChromeLow="#212121"
                     ChromeMedium="#212121"
                     ChromeMediumLow="#181818"
-                    ChromeWhite="#FFFFFF"
+                    ChromeWhite="#FFF"
                     ListLow="#212121"
                     ListMedium="#1A73E8" />
                 <ResourceDictionary>
+                    <!-- Accent Color -->
+                    <Color x:Key="SystemAccentColor">#1A73E8</Color>
+                    <Color x:Key="SystemAccentColorLight1">#1A73E8</Color>
+                    <Color x:Key="SystemAccentColorLight2">#1A73E8</Color>
+                    <Color x:Key="SystemAccentColorLight3">#1A73E8</Color>
+                    <Color x:Key="SystemAccentColorDark1">#1A73E8</Color>
+                    <Color x:Key="SystemAccentColorDark2">#1A73E8</Color>
+                    <Color x:Key="SystemAccentColorDark3">#1A73E8</Color>
+                    <!-- Acrylic Resources -->
                     <Color x:Key="SolidBackgroundAcrylic">#181818</Color>
-                    <Color x:Key="SolidBackgroundFillColorBase">#000000</Color>
-                    <Color x:Key="SolidBackgroundFillColorSecondary">#000000</Color>
+                    <!-- Background Resources -->
+                    <Color x:Key="SolidBackgroundAcrylic">#181818</Color>
+                    <Color x:Key="SolidBackgroundFillColorBase">#181818</Color>
+                    <Color x:Key="SolidBackgroundFillColorSecondary">#000</Color>
                     <Color x:Key="SolidBackgroundFillColorTertiary">#181818</Color>
                     <Color x:Key="SolidBackgroundFillColorQuarternary">#181818</Color>
                     <SolidColorBrush x:Key="SolidBackgroundFillColorBaseBrush" Color="{ThemeResource SolidBackgroundFillColorBase}" />
                     <SolidColorBrush x:Key="SolidBackgroundFillColorSecondaryBrush" Color="{ThemeResource SolidBackgroundFillColorSecondary}" />
                     <SolidColorBrush x:Key="SolidBackgroundFillColorTertiaryBrush" Color="{ThemeResource SolidBackgroundFillColorTertiary}" />
                     <SolidColorBrush x:Key="SolidBackgroundFillColorQuarternaryBrush" Color="{ThemeResource SolidBackgroundFillColorQuarternary}" />
-                    <Color x:Key="ControlStrokeColorDefault">#000000</Color>
-                    <Color x:Key="ControlStrokeColorSecondary">#000000</Color>
+                    <Color x:Key="ControlStrokeColorDefault">#000</Color>
+                    <Color x:Key="ControlStrokeColorSecondary">#000</Color>
                     <SolidColorBrush x:Key="ControlFillColorDefaultBrush" Color="#181818" />
                     <SolidColorBrush x:Key="ControlFillColorSecondaryBrush" Color="#212121" />
                     <SolidColorBrush x:Key="ControlFillColorTertiaryBrush" Color="#212121" />
                     <SolidColorBrush x:Key="ControlFillColorInputActiveBrush" Color="#212121" />
-                    <CornerRadius x:Key="ControlCornerRadius">8,8,8,8</CornerRadius>
-                    <CornerRadius x:Key="OverlayCornerRadius">8,8,8,8</CornerRadius>
+                    <!-- Corners -->
+                    <CornerRadius x:Key="ControlCornerRadius">8</CornerRadius>
+                    <CornerRadius x:Key="OverlayCornerRadius">8</CornerRadius>
+                    <!-- File Browser Control Background -->
+                    <SolidColorBrush x:Key="FileBrowserBackgroundBrush" Color="{ThemeResource SolidBackgroundFillColorSecondary}" />
+                    <!-- Sidebar -->
+                    <x:Double x:Key="SidebarTintOpacity">1</x:Double>
+                    <x:Double x:Key="SidebarTintLuminosityOpacity">1</x:Double>
+                    <!-- Status Bar Background -->
+                    <SolidColorBrush x:Key="StatusBarBackgroundBrush" Color="{ThemeResource SolidBackgroundFillColorTertiary}" />
+                    <!-- Tab Resources -->
+                    <SolidColorBrush x:Key="TabViewItemHeaderBackground" Color="{ThemeResource SolidBackgroundFillColorBase}" />
+                    <SolidColorBrush x:Key="TabViewItemHeaderBackgroundSelected" Color="{ThemeResource SolidBackgroundFillColorSecondary}" />
+                    <SolidColorBrush x:Key="TabViewItemHeaderBackgroundPointerOver" Color="#212121" />
+                    <!-- Toolbar Background -->
+                    <SolidColorBrush x:Key="NavigationToolbarBackgroundBrush" Color="{ThemeResource SolidBackgroundFillColorSecondary}" />
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 </ResourceDictionary>
+


### PR DESCRIPTION
* Override accent colors in the new settings UI
* Fix background being opaque instead of semitransparent for when the new settings are open 
* Switch up current and background tab colors to match Google Chrome's style instead
* Dark gray fallback background color for the sidebar
* Cleanup & additional refactoring

![image](https://user-images.githubusercontent.com/34194191/121821652-fb6e2500-cca2-11eb-99d0-0adeec4fa50c.png)
